### PR TITLE
Add shipping options and updated order flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ test/
   e2e/             End to end scenarios
 ```
 
-The services contain simple in-memory logic to keep the example concise. Payment and shipping are simulated via asynchronous services.
+The services contain simple in-memory logic to keep the example concise. Payment and shipping are simulated via asynchronous services. A list of shipping options is exposed via `/shipping` and orders must specify a `shippingMethod` when created. The `ProductService` can optionally fetch products from an external `json-server` API when `PRODUCT_API_URL` is set.

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { OrderService } from './services/orderService';
 import { ProductController } from './controllers/productController';
 import { CartController } from './controllers/cartController';
 import { OrderController } from './controllers/orderController';
+import { ShippingController } from './controllers/shippingController';
 
 const app = express();
 app.use(express.json());
@@ -19,6 +20,7 @@ const orderService = new OrderService(cartService, paymentService, shippingServi
 const productController = new ProductController(productService);
 const cartController = new CartController(cartService);
 const orderController = new OrderController(orderService);
+const shippingController = new ShippingController(shippingService);
 
 app.locals.cartService = cartService;
 
@@ -26,6 +28,7 @@ app.get('/products', productController.getProducts);
 app.post('/cart/items', cartController.addItem);
 app.get('/cart', cartController.getCart);
 app.post('/orders', orderController.createOrder);
+app.get('/shipping', shippingController.getOptions);
 
 export default app;
 

--- a/src/controllers/orderController.ts
+++ b/src/controllers/orderController.ts
@@ -5,7 +5,8 @@ export class OrderController {
   constructor(private orderService: OrderService) {}
 
   createOrder = async (req: Request, res: Response): Promise<void> => {
-    const order = await this.orderService.createOrder();
+    const { shippingMethod } = req.body;
+    const order = await this.orderService.createOrder(shippingMethod);
     res.status(201).json(order);
   };
 }

--- a/src/controllers/shippingController.ts
+++ b/src/controllers/shippingController.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from 'express';
+import { ShippingService } from '../services/shippingService';
+
+export class ShippingController {
+  constructor(private shippingService: ShippingService) {}
+
+  getOptions = (req: Request, res: Response): void => {
+    res.json(this.shippingService.getOptions());
+  };
+}

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -3,6 +3,8 @@ import { CartItem } from './cartItem';
 export interface Order {
   id: string;
   items: CartItem[];
+  shippingMethod: string;
+  shippingCost: number;
   total: number;
   status: 'pending' | 'paid' | 'shipped';
 }

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -13,18 +13,31 @@ export class OrderService {
     private productService: ProductService
   ) {}
 
-  async createOrder(): Promise<Order> {
+  async createOrder(shippingMethod: string): Promise<Order> {
     const items = this.cartService.getItems();
-    const total = items.reduce((sum, item) => {
+    const itemsTotal = items.reduce((sum, item) => {
       const product = this.productService.findById(item.productId);
       return product ? sum + product.price * item.quantity : sum;
     }, 0);
 
-    const order: Order = { id: uuidv4(), items, total, status: 'pending' };
-    const paymentSuccess = await this.paymentService.processPayment(order.id, order.total);
+    const shippingCost = this.shippingService.getCost(shippingMethod);
+    const total = itemsTotal + shippingCost;
+
+    const order: Order = {
+      id: uuidv4(),
+      items,
+      shippingMethod,
+      shippingCost,
+      total,
+      status: 'pending'
+    };
+    const paymentSuccess = await this.paymentService.processPayment(
+      order.id,
+      order.total
+    );
     if (paymentSuccess) {
       order.status = 'paid';
-      await this.shippingService.shipOrder(order.id);
+      await this.shippingService.shipOrder(order.id, shippingMethod);
       order.status = 'shipped';
     }
     this.cartService.clear();

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -6,8 +6,21 @@ const products: Product[] = [
 ];
 
 export class ProductService {
+  constructor(private apiUrl: string | undefined = process.env.PRODUCT_API_URL) {}
+
   getAll(): Product[] {
     return products;
+  }
+
+  async fetchAll(): Promise<Product[]> {
+    if (!this.apiUrl) {
+      return Promise.resolve(products);
+    }
+    const res = await fetch(`${this.apiUrl}/products`);
+    if (!res.ok) {
+      throw new Error('Failed to fetch products');
+    }
+    return res.json();
   }
 
   findById(id: string): Product | undefined {

--- a/src/services/shippingService.ts
+++ b/src/services/shippingService.ts
@@ -1,6 +1,25 @@
+export interface ShippingOption {
+  id: string;
+  name: string;
+  price: number;
+}
+
+const options: ShippingOption[] = [
+  { id: 'standard', name: 'Standard', price: 5 },
+  { id: 'express', name: 'Express', price: 10 }
+];
+
 export class ShippingService {
-  async shipOrder(orderId: string): Promise<void> {
-    // simulate external shipping API
+  getOptions(): ShippingOption[] {
+    return options;
+  }
+
+  getCost(optionId: string): number {
+    return options.find(o => o.id === optionId)?.price ?? 0;
+  }
+
+  async shipOrder(orderId: string, optionId: string): Promise<void> {
+    // simulate external shipping API using selected option
     await new Promise(resolve => setTimeout(resolve, 50));
   }
 }

--- a/test/e2e/orderFlow.test.ts
+++ b/test/e2e/orderFlow.test.ts
@@ -6,9 +6,12 @@ describe('Order flow E2E', () => {
     const products = await request(app).get('/products');
     const productId = products.body[0].id;
     await request(app).post('/cart/items').send({ productId, quantity: 2 });
-    const orderRes = await request(app).post('/orders');
+    const orderRes = await request(app)
+      .post('/orders')
+      .send({ shippingMethod: 'standard' });
     expect(orderRes.status).toBe(201);
     expect(orderRes.body.items[0].productId).toBe(productId);
+    expect(orderRes.body.shippingCost).toBe(5);
     expect(orderRes.body.status).toBe('shipped');
   });
 });

--- a/test/integration/app.test.ts
+++ b/test/integration/app.test.ts
@@ -25,8 +25,9 @@ describe('API', () => {
     const cartRes = await request(app).get('/cart');
     expect(cartRes.body.length).toBe(1);
 
-    const orderRes = await request(app).post('/orders');
+    const orderRes = await request(app).post('/orders').send({ shippingMethod: 'standard' });
     expect(orderRes.status).toBe(201);
+    expect(orderRes.body.shippingCost).toBe(5);
     expect(orderRes.body.status).toBe('shipped');
   });
 });

--- a/test/unit/orderService.test.ts
+++ b/test/unit/orderService.test.ts
@@ -15,15 +15,19 @@ describe('OrderService', () => {
   beforeEach(() => {
     cart = new CartService();
     payment = { processPayment: vi.fn().mockResolvedValue(true) } as unknown as PaymentService;
-    shipping = { shipOrder: vi.fn().mockResolvedValue(undefined) } as unknown as ShippingService;
+    shipping = {
+      shipOrder: vi.fn().mockResolvedValue(undefined),
+      getCost: vi.fn().mockReturnValue(5)
+    } as unknown as ShippingService;
     productService = new ProductService();
     service = new OrderService(cart, payment, shipping, productService);
   });
 
   it('creates order from cart', async () => {
     cart.addItem('1', 1);
-    const order = await service.createOrder();
+    const order = await service.createOrder('standard');
     expect(order.status).toBe('shipped');
+    expect(order.shippingCost).toBe(5);
     expect((payment.processPayment as any).mock.calls[0][1]).toBe(order.total);
   });
 });


### PR DESCRIPTION
## Summary
- add shipping method and cost to Order model
- implement ShippingService with selectable options
- refactor OrderService to include shipping cost and selected method
- expose `/shipping` endpoint via new ShippingController
- adjust controllers and tests for the new order flow
- document shipping options and optional external product API

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acec55fe0832daabcd027e7700d59