### PR TITLE
Serve catalog pages with static assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+PORT=3000
+#PRODUCT_API_URL=http://localhost:4001

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  env: {
+    node: true,
+    es2020: true
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  ignorePatterns: ['dist/', 'node_modules/'],
+  rules: {}
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ This project provides a small example of a Node.js backend written in TypeScript
 ## Project Structure
 ```
 src/
-  controllers/     Express route handlers
+  config/          Environment handling
+  server.ts        Application entry point
+  app.ts           Express instance
+  routes/          Route definitions
+  controllers/     Express handlers
   services/        Business logic
   models/          Type definitions
-  app.ts           Express application
+  views/           Static HTML pages
+  public/          Browser JS and CSS
 
 test/
   unit/            Unit tests for services

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/app.ts",
-    "start": "tsx src/app.ts",
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts",
     "test": "vitest",
     "test:watch": "vitest --watch"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import path from 'path';
 import { fileURLToPath } from 'url';
 import { ProductService } from './services/productService';
 import { CartService } from './services/cartService';
@@ -9,9 +10,15 @@ import { ProductController } from './controllers/productController';
 import { CartController } from './controllers/cartController';
 import { OrderController } from './controllers/orderController';
 import { ShippingController } from './controllers/shippingController';
+import { SiteController } from './controllers/siteController';
+import { registerRoutes } from './routes/index.route';
 
 const app = express();
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+app.use(express.static(path.join(__dirname, 'public')));
 
 const productService = new ProductService();
 const cartService = new CartService();
@@ -22,18 +29,16 @@ const productController = new ProductController(productService);
 const cartController = new CartController(cartService);
 const orderController = new OrderController(orderService);
 const shippingController = new ShippingController(shippingService);
+const siteController = new SiteController(productService, cartService, orderService);
 
 app.locals.cartService = cartService;
 
-app.get('/products', productController.getProducts);
-app.post('/cart/items', cartController.addItem);
-app.get('/cart', cartController.getCart);
-app.post('/orders', orderController.createOrder);
-app.get('/shipping', shippingController.getOptions);
+registerRoutes(app, {
+  product: productController,
+  cart: cartController,
+  order: orderController,
+  shipping: shippingController,
+  site: siteController
+});
 
 export default app;
-
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const port = process.env.PORT || 3000;
-  app.listen(port, () => console.log(`Server running on port ${port}`));
-}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,9 @@
+export interface Env {
+  PORT?: string;
+  PRODUCT_API_URL?: string;
+}
+
+export const env: Env = {
+  PORT: process.env.PORT,
+  PRODUCT_API_URL: process.env.PRODUCT_API_URL
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,6 @@
+import { env } from './env';
+
+export const config = {
+  port: Number(env.PORT) || 3000,
+  productApiUrl: env.PRODUCT_API_URL
+};

--- a/src/controllers/cartController.ts
+++ b/src/controllers/cartController.ts
@@ -5,9 +5,14 @@ export class CartController {
   constructor(private cartService: CartService) {}
 
   addItem = (req: Request, res: Response): void => {
-    const { productId, quantity } = req.body;
-    this.cartService.addItem(productId, quantity);
-    res.status(201).end();
+    const { productId, quantity } = req.body as any;
+    const qty = Number(quantity) || 1;
+    this.cartService.addItem(productId, qty);
+    if (req.is('application/json')) {
+      res.status(201).end();
+    } else {
+      res.redirect('/cart');
+    }
   };
 
   getCart = (req: Request, res: Response): void => {

--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -7,4 +7,13 @@ export class ProductController {
   getProducts = (req: Request, res: Response): void => {
     res.json(this.productService.getAll());
   };
+
+  getProduct = (req: Request, res: Response): void => {
+    const product = this.productService.findById(req.params.id);
+    if (!product) {
+      res.status(404).end();
+      return;
+    }
+    res.json(product);
+  };
 }

--- a/src/controllers/siteController.ts
+++ b/src/controllers/siteController.ts
@@ -1,0 +1,52 @@
+import { Request, Response } from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { ProductService } from '../services/productService';
+import { CartService } from '../services/cartService';
+import { OrderService } from '../services/orderService';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const viewsDir = path.join(__dirname, '../views');
+
+export class SiteController {
+  constructor(
+    private productService: ProductService,
+    private cartService: CartService,
+    private orderService: OrderService
+  ) {}
+
+  home = (_req: Request, res: Response): void => {
+    res.sendFile(path.join(viewsDir, 'index.html'));
+  };
+
+  productPage = (_req: Request, res: Response): void => {
+    res.sendFile(path.join(viewsDir, 'product.html'));
+  };
+
+  cartPage = (req: Request, res: Response): void => {
+    const items = this.cartService.getItems();
+    const rows = items
+      .map(i => {
+        const product = this.productService.findById(i.productId);
+        const name = product?.name ?? i.productId;
+        return `<li>${name} x ${i.quantity}</li>`;
+      })
+      .join('');
+    res.send(
+      `<h1>Cart</h1><ul>${rows}</ul>` +
+        `<form method="post" action="/checkout">` +
+        `<select name="shippingMethod">` +
+        `<option value="standard">Standard</option>` +
+        `<option value="express">Express</option>` +
+        `</select>` +
+        `<button type="submit">Checkout</button>` +
+        `</form>`
+    );
+  };
+
+  checkout = async (req: Request, res: Response): Promise<void> => {
+    const { shippingMethod } = req.body as any;
+    const order = await this.orderService.createOrder(shippingMethod);
+    res.send(`<h1>Order ${order.id}</h1><p>Status: ${order.status}</p>`);
+  };
+}

--- a/src/middlewares/error.middleware.ts
+++ b/src/middlewares/error.middleware.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function errorHandler(err: any, req: Request, res: Response, next: NextFunction) {
+  console.error(err);
+  res.status(500).json({ message: 'Internal Server Error' });
+}

--- a/src/public/index.js
+++ b/src/public/index.js
@@ -1,0 +1,31 @@
+const listEl = document.getElementById('product-list');
+const paginationEl = document.getElementById('pagination');
+let currentPage = 1;
+const perPage = 12;
+
+async function loadProducts(page) {
+  const res = await fetch('/api/products');
+  const products = await res.json();
+  const start = (page - 1) * perPage;
+  const pageItems = products.slice(start, start + perPage);
+  listEl.innerHTML = pageItems
+    .map(p => `<li><a href="/products/${p.id}">${p.name} - $${p.price}</a></li>`)
+    .join('');
+  const pages = Math.ceil(products.length / perPage);
+  paginationEl.innerHTML = '';
+  for (let i = 1; i <= pages; i++) {
+    const link = document.createElement('a');
+    link.href = '#';
+    link.textContent = i;
+    if (i === page) link.style.fontWeight = 'bold';
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      currentPage = i;
+      loadProducts(i);
+    });
+    paginationEl.appendChild(link);
+    paginationEl.appendChild(document.createTextNode(' '));
+  }
+}
+
+loadProducts(currentPage);

--- a/src/public/main.css
+++ b/src/public/main.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 20px; }
+ul { list-style: none; padding: 0; }
+li { margin-bottom: 10px; }

--- a/src/public/product.js
+++ b/src/public/product.js
@@ -1,0 +1,16 @@
+const detailEl = document.getElementById('product-detail');
+const id = location.pathname.split('/').pop();
+fetch(`/api/products/${id}`)
+  .then(r => r.json())
+  .then(p => {
+    detailEl.innerHTML = `
+      <h1>${p.name}</h1>
+      <p>Price: $${p.price}</p>
+      <form method="post" action="/cart/items">
+        <input type="hidden" name="productId" value="${p.id}">
+        <input type="number" name="quantity" value="1" min="1">
+        <button type="submit">Add to Cart</button>
+      </form>
+      <a href="/">Back to catalogue</a>
+    `;
+  });

--- a/src/routes/index.route.ts
+++ b/src/routes/index.route.ts
@@ -1,0 +1,29 @@
+import { Router, Express } from 'express';
+import { ProductController } from '../controllers/productController';
+import { CartController } from '../controllers/cartController';
+import { OrderController } from '../controllers/orderController';
+import { ShippingController } from '../controllers/shippingController';
+import { SiteController } from '../controllers/siteController';
+
+export function registerRoutes(app: Express,
+  controllers: {
+    product: ProductController;
+    cart: CartController;
+    order: OrderController;
+    shipping: ShippingController;
+    site: SiteController;
+  }) {
+  const api = Router();
+  api.get('/products', controllers.product.getProducts);
+  api.get('/products/:id', controllers.product.getProduct);
+  api.post('/cart/items', controllers.cart.addItem);
+  api.get('/cart', controllers.cart.getCart);
+  api.post('/orders', controllers.order.createOrder);
+  api.get('/shipping', controllers.shipping.getOptions);
+  app.use('/api', api);
+
+  app.get('/', controllers.site.home);
+  app.get('/products/:id', controllers.site.productPage);
+  app.get('/cart', controllers.site.cartPage);
+  app.post('/checkout', controllers.site.checkout);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'url';
+import app from './app';
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+export {}; // to make this an ES module

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,11 @@
+import { CartService } from '../services/cartService';
+declare global {
+  namespace Express {
+    interface Application {
+      locals: {
+        cartService: CartService;
+      };
+    }
+  }
+}
+export {};

--- a/src/views/index.html
+++ b/src/views/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Products</title>
+  <link rel="stylesheet" href="/main.css" />
+</head>
+<body>
+  <h1>Catalogue</h1>
+  <ul id="product-list"></ul>
+  <div id="pagination"></div>
+  <script src="/index.js"></script>
+</body>
+</html>

--- a/src/views/product.html
+++ b/src/views/product.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Product Details</title>
+  <link rel="stylesheet" href="/main.css" />
+</head>
+<body>
+  <div id="product-detail"></div>
+  <script src="/product.js"></script>
+</body>
+</html>

--- a/test/e2e/orderFlow.test.ts
+++ b/test/e2e/orderFlow.test.ts
@@ -4,11 +4,11 @@ import { describe, it, expect } from 'vitest';
 
 describe('Order flow E2E', () => {
   it('user can browse, add to cart and order', async () => {
-    const products = await request(app).get('/products');
+    const products = await request(app).get('/api/products');
     const productId = products.body[0].id;
-    await request(app).post('/cart/items').send({ productId, quantity: 2 });
+    await request(app).post('/api/cart/items').send({ productId, quantity: 2 });
     const orderRes = await request(app)
-      .post('/orders')
+      .post('/api/orders')
       .send({ shippingMethod: 'standard' });
     expect(orderRes.status).toBe(201);
     expect(orderRes.body.items[0].productId).toBe(productId);

--- a/test/integration/app.test.ts
+++ b/test/integration/app.test.ts
@@ -12,20 +12,28 @@ afterEach(() => {
 
 describe('API', () => {
   it('lists products', async () => {
-    const res = await request(app).get('/products');
+    const res = await request(app).get('/api/products');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
   });
 
+  it('gets product by id', async () => {
+    const list = await request(app).get('/api/products');
+    const id = list.body[0].id;
+    const res = await request(app).get(`/api/products/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.id).toBe(id);
+  });
+
   it('can create order flow', async () => {
-    const productRes = await request(app).get('/products');
+    const productRes = await request(app).get('/api/products');
     const productId = productRes.body[0].id;
 
-    await request(app).post('/cart/items').send({ productId, quantity: 1 });
-    const cartRes = await request(app).get('/cart');
+    await request(app).post('/api/cart/items').send({ productId, quantity: 1 });
+    const cartRes = await request(app).get('/api/cart');
     expect(cartRes.body.length).toBe(1);
 
-    const orderRes = await request(app).post('/orders').send({ shippingMethod: 'standard' });
+    const orderRes = await request(app).post('/api/orders').send({ shippingMethod: 'standard' });
     expect(orderRes.status).toBe(201);
     expect(orderRes.body.shippingCost).toBe(5);
     expect(orderRes.body.status).toBe('shipped');

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["test", "**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/importMeta"]
+  }
+}


### PR DESCRIPTION
## Summary
- expose product detail endpoint
- serve static assets and HTML pages
- add simple frontend scripts for catalogue and product pages
- document new directories in the README
- test product lookup API

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aea1e6448832d92feef9a701feb67