### PR TITLE
Fix test configuration without cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "tsx src/server.ts",
-    "test": "cross-env NODE_ENV=test vitest run",
+    "test": "NODE_ENV=test vitest run",
     "test:watch": "vitest --watch"
   },
   "dependencies": {
@@ -23,7 +23,6 @@
     "@types/node": "^20.2.5",
     "@types/supertest": "^6.0.3",
     "@types/uuid": "^10.0.0",
-    "cross-env": "^7.0.3",
     "supertest": "^6.3.4",
     "tsx": "^3.12.7",
     "typescript": "^5.1.3",

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'node'
+    environment: 'node',
+    setupFiles: ['./test/setup.ts']
   }
 });


### PR DESCRIPTION
## Summary
- remove cross-env dependency
- configure Vitest to load a setup file
- set NODE_ENV in `test/setup.ts`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d45cb8a4832db166a1794201b855